### PR TITLE
Compatibility with the original game engine

### DIFF
--- a/MikuMikuWorld/StringOperations.h
+++ b/MikuMikuWorld/StringOperations.h
@@ -6,7 +6,7 @@
 
 namespace MikuMikuWorld
 {
-    constexpr const char digits[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    constexpr const char digits[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
     char* reverse(char* str);
 	char* tostringBaseN(char* buff, long long num, int base);


### PR DESCRIPTION
Just a small change in the StringOperation.h to allow modding the exported chart into the original game because it only accepts lowercase letter and ignores uppercase.