### PR TITLE
Fix drag-select bug

### DIFF
--- a/MikuMikuWorld/EditorWindows.cpp
+++ b/MikuMikuWorld/EditorWindows.cpp
@@ -84,10 +84,12 @@ namespace MikuMikuWorld
 				mousePos = io.MousePos - canvas.getPosition();
 				mousePos.y -= canvas.getOffset();
 
-				if (!isHoveringNote && !isHoldingNote && !insertingHold && ImGui::IsWindowFocused())
+				if (!isHoveringNote && !isHoldingNote && !insertingHold /*&& ImGui::IsWindowFocused()*/)
 				{
 					if (ImGui::IsMouseDown(0) && ImGui::IsMouseDragPastThreshold(0, 10.0f))
-						dragging = true;
+						dragging = true & (currentMode == TimelineMode::Select);
+					// The above line was just draggin = true; I added the later part because it seem like being able to drag-select while in other mode is not intended
+					// as dragStart is not updated at all while in other mode
 
 					if (ImGui::IsMouseClicked(0))
 					{


### PR DESCRIPTION
Fix for issue#6 I just opened

Also since dragStart is not updated at all while using modes other than Select, I think being able to drag-select while in other mode is not intended so I change that as well in this PR.

If it's intended then just need to disable the ImGui::IsWindowFocused() condition for this.