### PR TITLE
Fix: Support Japanese path

### DIFF
--- a/MikuMikuWorld/FileDialog.cpp
+++ b/MikuMikuWorld/FileDialog.cpp
@@ -76,7 +76,7 @@ namespace MikuMikuWorld
 
 		if (GetOpenFileNameW(&ofn))
 		{
-			name = wideStringToMb(ofn.lpstrFile);
+			name = wideAnsiStringToMb(ofn.lpstrFile);
 			return true;
 		}
 
@@ -110,7 +110,7 @@ namespace MikuMikuWorld
 
 		if (GetSaveFileNameW(&ofn))
 		{
-			name = wideStringToMb(ofn.lpstrFile);
+			name = wideAnsiStringToMb(ofn.lpstrFile);
 			return true;
 		}
 

--- a/MikuMikuWorld/StringOperations.cpp
+++ b/MikuMikuWorld/StringOperations.cpp
@@ -115,6 +115,15 @@ namespace MikuMikuWorld
 		return result;
 	}
 
+	std::string wideAnsiStringToMb(const std::wstring& str)
+	{
+		int size = WideCharToMultiByte(CP_ACP, 0, &str[0], (int)str.size(), NULL, 0, NULL, NULL);
+		std::string result(size, 0);
+		WideCharToMultiByte(CP_ACP, 0, &str[0], (int)str.size(), &result[0], size, NULL, NULL);
+
+		return result;
+	}
+
 	std::wstring mbToWideStr(const std::string& str)
 	{
 		int size = MultiByteToWideChar(CP_UTF8, 0, &str[0], str.size(), NULL, 0);

--- a/MikuMikuWorld/StringOperations.h
+++ b/MikuMikuWorld/StringOperations.h
@@ -18,6 +18,7 @@ namespace MikuMikuWorld
 	std::vector<std::string> split(const std::string& line, const std::string& delim);
 
 	std::string wideStringToMb(const std::wstring& str);
+	std::string wideAnsiStringToMb(const std::wstring& str);
 	std::wstring mbToWideStr(const std::string& str);
 
 	template<typename ... Args>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59691627/187003677-8b89e345-1461-47c8-afe3-434bfa924649.png)

This PR fixes the error when user try to load sus file in directory that includes multibyte character, such as Japanese.

I'm new to C++, so I may did something bad.