### PR TITLE
Fix potential string_view overflow when parsing empty lines

### DIFF
--- a/MikuMikuWorld/IO.cpp
+++ b/MikuMikuWorld/IO.cpp
@@ -87,11 +87,17 @@ namespace IO
 
 	bool startsWith(const std::string_view& line, const std::string_view& key)
 	{
+		if (line.length() < key.length())
+			return false;
+
 		return std::equal(key.begin(), key.end(), line.begin());
 	}
 
 	bool endsWith(const std::string_view& line, const std::string_view& key)
 	{
+		if (line.length() < key.length())
+			return false;
+
 		return std::equal(key.rbegin(), key.rend(), line.rbegin());
 	}
 


### PR DESCRIPTION
Found by opening `.sus` files (under debug mode) where empty `line`s are passed to the `startsWith()` function.
This issue does not crash the current released version, but it does trigger an assertion error when run in debug mode.