### PR TITLE
Use `std::map` for all associative containers

### DIFF
--- a/MikuMikuWorld/Audio/AudioManager.cpp
+++ b/MikuMikuWorld/Audio/AudioManager.cpp
@@ -85,8 +85,7 @@ namespace Audio
 		
 		for (size_t index = 0; index < soundEffectsProfileCount; index++)
 		{
-			std::string path = IO::formatString("%s%s%02d\\", mmw::Application::getAppDir().c_str(), "res\\sound\\", index + 1);
-			sounds[index].pool.reserve(soundEffectsCount);
+			std::string path = IO::formatString("%s%s%02d\\", mmw::Application::getAppDir().c_str(), "res\\sound\\", index + 1);			
 			for (size_t i = 0; i < soundEffectsCount; ++i)
 				sounds[index].pool.emplace(std::move(SoundPoolPair(mmw::SE_NAMES[i], std::make_unique<SoundPool>())));
 			

--- a/MikuMikuWorld/Audio/AudioManager.h
+++ b/MikuMikuWorld/Audio/AudioManager.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "Sound.h"
-#include <unordered_map>
+#include <map>
 #include <vector>
 #include <array>
 #include <memory>

--- a/MikuMikuWorld/Audio/Sound.h
+++ b/MikuMikuWorld/Audio/Sound.h
@@ -2,7 +2,7 @@
 #include <array>
 #include <string>
 #include <memory>
-#include <unordered_map>
+#include <map>
 #include <string_view>
 
 // Already defined somewhere else but Visual Studio gets confused
@@ -164,6 +164,6 @@ namespace Audio
 	struct SoundEffectProfile
 	{
 		std::string name;
-		std::unordered_map<std::string_view, std::unique_ptr<SoundPool>> pool;
+		std::map<std::string_view, std::unique_ptr<SoundPool>> pool;
 	};
 }

--- a/MikuMikuWorld/DefaultLanguage.h
+++ b/MikuMikuWorld/DefaultLanguage.h
@@ -1,10 +1,10 @@
 #pragma once
-#include <unordered_map>
+#include <map>
 #include <string>
 
 namespace MikuMikuWorld
 {
-	extern std::unordered_map<std::string, std::string> en
+	extern std::map<std::string, std::string> en
 	{
 		// Menu bar
 		{"file", "File"},

--- a/MikuMikuWorld/HistoryManager.h
+++ b/MikuMikuWorld/HistoryManager.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stack>
 #include <map>
-#include <unordered_map>
+#include <map>
 #include <string>
 #include "Score.h"
 

--- a/MikuMikuWorld/Language.cpp
+++ b/MikuMikuWorld/Language.cpp
@@ -15,7 +15,7 @@ namespace MikuMikuWorld
         read(filename);
     }
 
-	Language::Language(const char* code, std::string name, const std::unordered_map<std::string, std::string>& strings)
+	Language::Language(const char* code, std::string name, const std::map<std::string, std::string>& strings)
 	{
 		this->code = code;
 		displayName = name;
@@ -30,8 +30,7 @@ namespace MikuMikuWorld
 		File f(filename, FileMode::Read);
 		std::vector<std::string> lines = f.readAllLines();
 
-		f.close();
-        strings.reserve(lines.size());
+		f.close();        
 
 		for (auto& line : lines)
 		{

--- a/MikuMikuWorld/Language.h
+++ b/MikuMikuWorld/Language.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <unordered_map>
+#include <map>
 #include <string>
 
 namespace MikuMikuWorld
@@ -9,11 +9,11 @@ namespace MikuMikuWorld
     private:
         std::string code;
         std::string displayName;
-        std::unordered_map<std::string, std::string> strings;
+        std::map<std::string, std::string> strings;
 
 	public:
         Language(const char* code, std::string name, const std::string& filename);
-        Language(const char* code, std::string name, const std::unordered_map<std::string, std::string>& strings);
+        Language(const char* code, std::string name, const std::map<std::string, std::string>& strings);
 
 		void read(const std::string& filename);
         const char* getCode() const;

--- a/MikuMikuWorld/Localization.cpp
+++ b/MikuMikuWorld/Localization.cpp
@@ -8,7 +8,7 @@ namespace MikuMikuWorld
 {
 	static std::string empty;
 
-	std::unordered_map<std::string, std::unique_ptr<Language>> Localization::languages;
+	std::map<std::string, std::unique_ptr<Language>> Localization::languages;
 	Language* Localization::currentLanguage = nullptr;
 
 	void Localization::load(const char* code, std::string name, const std::string& filename)

--- a/MikuMikuWorld/Localization.h
+++ b/MikuMikuWorld/Localization.h
@@ -9,7 +9,7 @@ namespace MikuMikuWorld
     private:
 
 	public:
-		static std::unordered_map<std::string, std::unique_ptr<Language>> languages;
+		static std::map<std::string, std::unique_ptr<Language>> languages;
 		static Language* currentLanguage;
 
 		static void load(const char* code, std::string name, const std::string& filename);

--- a/MikuMikuWorld/NotesPreset.cpp
+++ b/MikuMikuWorld/NotesPreset.cpp
@@ -128,8 +128,7 @@ namespace MikuMikuWorld
 				filenames.push_back(IO::wideStringToMb(file.path().wstring()));
 		}
 
-		std::mutex m2;
-		presets.reserve(filenames.size());
+		std::mutex m2;		
 
 		std::vector<Result> warnings;
 		std::vector<Result> errors;

--- a/MikuMikuWorld/NotesPreset.h
+++ b/MikuMikuWorld/NotesPreset.h
@@ -40,7 +40,7 @@ namespace MikuMikuWorld
 	public:
 		PresetManager(const std::string& path);
 		
-		std::unordered_map<int, NotesPreset> presets;
+		std::map<int, NotesPreset> presets;
 		NotesPreset deletedPreset{};
 
 		inline const std::wstring_view getPresetsPath() const { return presetsPath.c_str(); }

--- a/MikuMikuWorld/Rendering/Shader.h
+++ b/MikuMikuWorld/Rendering/Shader.h
@@ -2,7 +2,7 @@
 #include <glad/glad.h>
 #include "DirectXMath.h"
 #include <string>
-#include <unordered_map>
+#include <map>
 
 namespace MikuMikuWorld
 {
@@ -12,7 +12,7 @@ namespace MikuMikuWorld
 		unsigned int ID;
 		unsigned int uloc;
 		std::string name;
-		std::unordered_map<std::string, GLint> locMap;
+		std::map<std::string, GLint> locMap;
 
 		void compile(const std::string& source);
 		GLint getUniformLoc(const std::string& name);

--- a/MikuMikuWorld/SUS.h
+++ b/MikuMikuWorld/SUS.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <unordered_map>
+#include <map>
 #include <vector>
 #include <string>
 
@@ -40,7 +40,7 @@ namespace MikuMikuWorld
 
 	struct SUSMetadata
 	{
-		std::unordered_map<std::string, std::string> data;
+		std::map<std::string, std::string> data;
 		std::vector<std::string> requests;
 		float waveOffset;
 		float movieOffset;

--- a/MikuMikuWorld/Score.cpp
+++ b/MikuMikuWorld/Score.cpp
@@ -218,8 +218,7 @@ namespace MikuMikuWorld
 		if (version > 2)
 			reader.seek(tapsAddress);
 
-		int noteCount = reader.readInt32();
-		score.notes.reserve(noteCount);
+		int noteCount = reader.readInt32();		
 		for (int i = 0; i < noteCount; ++i)
 		{
 			Note note = readNote(NoteType::Tap, &reader);
@@ -230,8 +229,7 @@ namespace MikuMikuWorld
 		if (version > 2)
 			reader.seek(holdsAddress);
 
-		int holdCount = reader.readInt32();
-		score.holdNotes.reserve(holdCount);
+		int holdCount = reader.readInt32();		
 		for (int i = 0; i < holdCount; ++i)
 		{
 			HoldNote hold;

--- a/MikuMikuWorld/Score.h
+++ b/MikuMikuWorld/Score.h
@@ -3,7 +3,7 @@
 #include "Tempo.h"
 #include <string>
 #include <map>
-#include <unordered_map>
+#include <map>
 #include <vector>
 
 namespace MikuMikuWorld
@@ -41,8 +41,8 @@ namespace MikuMikuWorld
 	struct Score
 	{
 		ScoreMetadata metadata;
-		std::unordered_map<int, Note> notes;
-		std::unordered_map<int, HoldNote> holdNotes;
+		std::map<int, Note> notes;
+		std::map<int, HoldNote> holdNotes;
 		std::vector<Tempo> tempoChanges;
 		std::map<int, TimeSignature> timeSignatures;
 		std::vector<HiSpeedChange> hiSpeedChanges;

--- a/MikuMikuWorld/ScoreContext.h
+++ b/MikuMikuWorld/ScoreContext.h
@@ -53,8 +53,8 @@ namespace MikuMikuWorld
 
 	struct PasteData
 	{
-		std::unordered_map<int, Note> notes;
-		std::unordered_map<int, HoldNote> holds;
+		std::map<int, Note> notes;
+		std::map<int, HoldNote> holds;
 		bool pasting{ false };
 		int minTick{};
 		int offsetTicks{};

--- a/MikuMikuWorld/ScoreConverter.cpp
+++ b/MikuMikuWorld/ScoreConverter.cpp
@@ -45,7 +45,7 @@ namespace MikuMikuWorld
 			sus.metadata.waveOffset * 1000 // seconds -> milliseconds
 		};
 
-		std::unordered_map<std::string, FlickType> flicks;
+		std::map<std::string, FlickType> flicks;
 		std::unordered_set<std::string> criticals;
 		std::unordered_set<std::string> stepIgnore;
 		std::unordered_set<std::string> easeIns;
@@ -125,11 +125,8 @@ namespace MikuMikuWorld
 			}
 		}
 
-		std::unordered_map<int, Note> notes;
-		notes.reserve(sus.taps.size());
-
-		std::unordered_map<int, HoldNote> holds;
-		holds.reserve(sus.slides.size());
+		std::map<int, Note> notes;		
+		std::map<int, HoldNote> holds;		
 
 		std::vector<SkillTrigger> skills;
 		Fever fever{ -1, -1 };

--- a/MikuMikuWorld/ScoreEditorTimeline.cpp
+++ b/MikuMikuWorld/ScoreEditorTimeline.cpp
@@ -1428,7 +1428,7 @@ namespace MikuMikuWorld
 		ImGui::PopID();
 	}
 
-	void ScoreEditorTimeline::drawHoldCurve(const HoldNote& hold, const std::unordered_map<int, Note>& notes, Renderer* renderer, const Color& tint, const int offsetTicks, const int offsetLane)
+	void ScoreEditorTimeline::drawHoldCurve(const HoldNote& hold, const std::map<int, Note>& notes, Renderer* renderer, const Color& tint, const int offsetTicks, const int offsetLane)
 	{
 		const Note& start = notes.at(hold.start.ID);
 		const Note& end = notes.at(hold.end);
@@ -1552,7 +1552,7 @@ namespace MikuMikuWorld
 		}
 	}
 
-	void ScoreEditorTimeline::drawHoldNote(const std::unordered_map<int, Note>& notes, const HoldNote& note, Renderer* renderer,
+	void ScoreEditorTimeline::drawHoldNote(const std::map<int, Note>& notes, const HoldNote& note, Renderer* renderer,
 		const Color& tint, const int offsetTicks, const int offsetLane)
 	{
 		const Note& start = notes.at(note.start.ID);

--- a/MikuMikuWorld/ScoreEditorTimeline.h
+++ b/MikuMikuWorld/ScoreEditorTimeline.h
@@ -158,9 +158,9 @@ namespace MikuMikuWorld
 
 		void drawWaveform(ScoreContext& context);
 
-		void drawHoldCurve(const HoldNote& hold, const std::unordered_map<int, Note>& notes, Renderer* renderer, const Color& tint, const int offsetTick = 0, const int offsetLane = 0);
+		void drawHoldCurve(const HoldNote& hold, const std::map<int, Note>& notes, Renderer* renderer, const Color& tint, const int offsetTick = 0, const int offsetLane = 0);
 		void drawHoldCurvePart(const Note& n1, const Note& n2, EaseType ease, bool isGuide, Renderer* renderer, const Color& tint, const int offsetTick = 0, const int offsetLane = 0);
-		void drawHoldNote(const std::unordered_map<int, Note>& notes, const HoldNote& note, Renderer* renderer, const Color& tint, const int offsetTicks = 0, const int offsetLane = 0);
+		void drawHoldNote(const std::map<int, Note>& notes, const HoldNote& note, Renderer* renderer, const Color& tint, const int offsetTicks = 0, const int offsetLane = 0);
 		void drawHoldMid(Note& note, HoldStepType type, Renderer* renderer, const Color& tint);
 		void drawOutline(const StepDrawData& data);
 		void drawFlickArrow(const Note& note, Renderer* renderer, const Color& tint, const int offsetTick = 0, const int offsetLane = 0);

--- a/MikuMikuWorld/SusExporter.cpp
+++ b/MikuMikuWorld/SusExporter.cpp
@@ -266,7 +266,7 @@ namespace MikuMikuWorld
 
 		std::reverse(barLengthTicks.begin(), barLengthTicks.end());
 
-		std::unordered_map<float, std::string> bpmIdentifiers;
+		std::map<float, std::string> bpmIdentifiers;
 		for (const auto& bpm : bpms)
 		{
 			char buf[10]{};

--- a/MikuMikuWorld/SusExporter.h
+++ b/MikuMikuWorld/SusExporter.h
@@ -2,7 +2,6 @@
 #include <string>
 #include <map>
 #include <vector>
-#include <unordered_map>
 
 namespace MikuMikuWorld
 {
@@ -10,7 +9,7 @@ namespace MikuMikuWorld
 	{
 	private:
 		struct TickRange { int start; int end; };
-		std::unordered_map<int, TickRange> channels;
+		std::map<int, TickRange> channels;
 
 	public:
 		ChannelProvider()

--- a/MikuMikuWorld/SusParser.h
+++ b/MikuMikuWorld/SusParser.h
@@ -28,7 +28,7 @@ namespace MikuMikuWorld
 		std::string title;
 		std::string artist;
 		std::string designer;
-		std::unordered_map<std::string, float> bpmDefinitions;
+		std::map<std::string, float> bpmDefinitions;
 		std::vector<Bar> bars;
 
 		bool isCommand(const std::string& line);


### PR DESCRIPTION
`std::unordered_map` does NOT have a well-defined iteration order - https://godbolt.org/z/E6e6Mfr5n demonstrates this behavior.

As a result channel numbers generated by https://github.com/crash5band/MikuMikuWorld/blob/724a85ae2972e50bd1fd16f725a9ae9db2a8fce7/MikuMikuWorld/SusExporter.cpp#L12 ...is (unnecessarily) not idempotent across platforms (compilers)

Loading the attached `.sus` file in a `MSVC` (Visual Studio) build and saving it again would result in a different file compared to doing so in a `Clang`(Clang for Visual Studio)/`GCC`(MinGW) build - it's easy to notice that at least the channel number is different across the two versions.
![image](https://github.com/user-attachments/assets/8cec8dfb-5b48-4c02-90a8-9eba269f6776)

---
Attachments:

[example.txt](https://github.com/user-attachments/files/19922345/example.txt)
