### PR TITLE
Enable GL_BLEND in OpenGL loader

### DIFF
--- a/MikuMikuWorld/OpenGlLoader.cpp
+++ b/MikuMikuWorld/OpenGlLoader.cpp
@@ -118,7 +118,7 @@ namespace MikuMikuWorld
 
 		glLineWidth(1.0f);
 		glPointSize(1.0f);
-		glEnablei(GL_BLEND, 0);
+		glEnable(GL_BLEND);
 		glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 		glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
 		glViewport(0, 0, width, height);


### PR DESCRIPTION
I have no idea how this was never caught, or why it only affects Wine, but because the blending was disabled, everything looks very weird on Wine. Here are some screenshots with and without:

<img width="628" height="644" alt="image" src="https://github.com/user-attachments/assets/d01592f2-acdd-412b-ac9a-5f78497c7aa4" />
<img width="628" height="644" alt="image" src="https://github.com/user-attachments/assets/d330272b-8078-44b1-9e0c-10bb7e3922bb" />

This pr just enables GL_BLEND and nothing else.