### PR TITLE
Increase tick for overlapping (tick,lane) groups in sus serialization

### DIFF
--- a/MikuMikuWorld/SusSerializer.cpp
+++ b/MikuMikuWorld/SusSerializer.cpp
@@ -492,7 +492,7 @@ namespace MikuMikuWorld
 		{
 			std::size_t operator()(const Channel& c) const
 			{
-				return std::hash<int>()(c.tick) ^ (std::hash<int>()(c.lane) << 1);
+				return std::hash<int64_t>()((static_cast<int64_t>(c.lane) << 32) + c.tick);
 			}
 		};
 		struct ChannelEqual

--- a/MikuMikuWorld/SusSerializer.cpp
+++ b/MikuMikuWorld/SusSerializer.cpp
@@ -483,35 +483,47 @@ namespace MikuMikuWorld
 		// milliseconds -> seconds
 		metadata.waveOffset = score.metadata.musicOffset / 1000.0f;
 
-		struct Channel {
+		struct Channel
+		{
 			int tick;
 			int lane;
 		};
-		struct ChannelHash {
-			std::size_t operator()(const Channel& c) const {
+		struct ChannelHash
+		{
+			std::size_t operator()(const Channel& c) const
+			{
 				return std::hash<int>()(c.tick) ^ (std::hash<int>()(c.lane) << 1);
 			}
 		};
-		struct ChannelEqual {
-			bool operator()(const Channel& a, const Channel& b) const {
+		struct ChannelEqual
+		{
+			bool operator()(const Channel& a, const Channel& b) const
+			{
 				return a.tick == b.tick && a.lane == b.lane;
 			}
 		};
 
 		std::unordered_set<Channel, ChannelHash, ChannelEqual> overlapDetection;
-		for (auto& container : {&taps, &directionals}) {
-			for (auto& note : *container) {
-				while (overlapDetection.find(Channel{ note.tick, note.lane }) != overlapDetection.end()) {
+		for (auto& container : {&taps, &directionals})
+		{
+			for (auto& note : *container)
+			{
+				while (overlapDetection.find(Channel{ note.tick, note.lane }) != overlapDetection.end())
+				{
 					// If there's already a note at this tick and lane, we'll try to move it by 1 tick until we find an empty spot
 					note.tick++;
 				}
 				overlapDetection.insert(Channel{ note.tick, note.lane });
 			}
 		}
-		for (auto& container : {&slides, &guides}) {
-			for (auto& innerContainer : *container) {
-				for (auto& note : innerContainer) {
-					while (overlapDetection.find(Channel{ note.tick, note.lane }) != overlapDetection.end()) {
+		for (auto& container : {&slides, &guides})
+		{
+			for (auto& innerContainer : *container)
+			{
+				for (auto& note : innerContainer)
+				{
+					while (overlapDetection.find(Channel{ note.tick, note.lane }) != overlapDetection.end())
+					{
 						// If there's already a note at this tick and lane, we'll try to move it by 1 tick until we find an empty spot
 						note.tick++;
 					}

--- a/MikuMikuWorld/SusSerializer.cpp
+++ b/MikuMikuWorld/SusSerializer.cpp
@@ -483,6 +483,43 @@ namespace MikuMikuWorld
 		// milliseconds -> seconds
 		metadata.waveOffset = score.metadata.musicOffset / 1000.0f;
 
+		struct Channel {
+			int tick;
+			int lane;
+		};
+		struct ChannelHash {
+			std::size_t operator()(const Channel& c) const {
+				return std::hash<int>()(c.tick) ^ (std::hash<int>()(c.lane) << 1);
+			}
+		};
+		struct ChannelEqual {
+			bool operator()(const Channel& a, const Channel& b) const {
+				return a.tick == b.tick && a.lane == b.lane;
+			}
+		};
+
+		std::unordered_set<Channel, ChannelHash, ChannelEqual> overlapDetection;
+		for (auto& container : {&taps, &directionals}) {
+			for (auto& note : *container) {
+				while (overlapDetection.find(Channel{ note.tick, note.lane }) != overlapDetection.end()) {
+					// If there's already a note at this tick and lane, we'll try to move it by 1 tick until we find an empty spot
+					note.tick++;
+				}
+				overlapDetection.insert(Channel{ note.tick, note.lane });
+			}
+		}
+		for (auto& container : {&slides, &guides}) {
+			for (auto& innerContainer : *container) {
+				for (auto& note : innerContainer) {
+					while (overlapDetection.find(Channel{ note.tick, note.lane }) != overlapDetection.end()) {
+						// If there's already a note at this tick and lane, we'll try to move it by 1 tick until we find an empty spot
+						note.tick++;
+					}
+					overlapDetection.insert(Channel{ note.tick, note.lane });
+				}
+			}
+		}
+
 		return SUS{ metadata, taps, directionals, slides, guides, bpms, barlengths, hiSpeeds };
 	}
 }


### PR DESCRIPTION
sus format isn't very good at overlapping points, and what people do currently is offset endpoints manually so that they dont overlap. this pr changes SusSerializer::scoreToSus to do an overlap check at the end to adjust overlapping ones.

this uses an unordered set to store (tick,lane) pairs so it might have little performance impact, but considering exporting already sorts everything this is miniscule compared to that.